### PR TITLE
feat: support customizable Telegram message template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,30 +11,34 @@ Gotigram is a standalone Telegram bot that bridges your [Gotify](https://gotify.
 ## Table of Contents
 
 - [Table of Contents](#table-of-contents)
-- [📋 Prerequisites](#-prerequisites)
+- [Prerequisites](#prerequisites)
+- [Environment Variables](#environment-variables)
   - [Required Environment Variables](#required-environment-variables)
-  - [Optional Subscriptions Configuration File](#optional-subscriptions-configuration-file)
-    - [Enabling the Config File](#enabling-the-config-file)
-    - [JSON File Format](#json-file-format)
-- [🔧 How to Get Your Telegram Token and Chat ID](#-how-to-get-your-telegram-token-and-chat-id)
-- [🚀 Getting Started](#-getting-started)
+  - [Optional Environment Variables](#optional-environment-variables)
+- [Subscriptions Configuration File](#subscriptions-configuration-file)
+  - [Enabling the Config File](#enabling-the-config-file)
+  - [JSON File Format](#json-file-format)
+- [How to Get Your Telegram Token and Chat ID](#how-to-get-your-telegram-token-and-chat-id)
+- [Getting Started](#getting-started)
   - [Option 1: Run Locally](#option-1-run-locally)
   - [Option 2: Run via Docker](#option-2-run-via-docker)
     - [Using a local build](#using-a-local-build)
     - [Using Docker Hub image](#using-docker-hub-image)
-- [💬 Bot Usage](#-bot-usage)
+- [Bot Usage](#bot-usage)
   - [Available Commands](#available-commands)
-- [📥 Subscribing to Applications](#-subscribing-to-applications)
-  - [Example](#example)
-- [🧾 License](#-license)
-- [🤝 Contributing](#-contributing)
+  - [Subscribing to Applications](#subscribing-to-applications)
+    - [Example](#example)
+- [License](#license)
+- [Contributing](#contributing)
 
-## 📋 Prerequisites
+## Prerequisites
 
 Before using Gotigram, ensure you have the following:
 
 - A running **Gotify server**
 - A **Telegram bot**
+
+## Environment Variables
 
 To connect Gotigram to these services, you must provide certain configuration values via environment variables.
 
@@ -48,24 +52,27 @@ To connect Gotigram to these services, you must provide certain configuration va
 | `TELEGRAM_TOKEN`      | Token for your Telegram bot                                                            |
 | `TELEGRAM_CHAT_ID`    | Your personal Telegram chat ID                                                         |
 
-### Optional Subscriptions Configuration File
+### Optional Environment Variables
+
+| Variable              | Description                                                                            |
+|-----------------------|----------------------------------------------------------------------------------------|
+| `SUBSCRIPTIONS_FILE`  | Path to a JSON file containing predefined subscriptions. Defaults to `subscriptions.json`. See [how to use](#optional-subscriptions-configuration-file). |
+| `TELEGRAM_TEMPLATE` | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `*{{.Title}}*\n\n{{.Message}}` (bold title, blank line, then message body). Messages are sent with Markdown parse mode. **Wrap in `'...'` or `"..."`.** | |
+
+
+## Subscriptions Configuration File
 
 Gotigram can optionally preload subscriptions at startup from a JSON configuration file. This allows you to define which applications should be subscribed automatically, without manually sending commands in Telegram after each restart.
 
-#### Enabling the Config File
+### Enabling the Config File
 
-Set the following optional environment variable:
-
-| Variable             | Description                                             |
-| -------------------- | ------------------------------------------------------- |
-| `SUBSCRIPTIONS_FILE` | Path to a JSON file containing predefined subscriptions. If not set, Gotigram uses a default file (`/app/subscriptions.json` inside containers). |
-| `TELEGRAM_TEMPLATE`  | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `*{{.Title}}*\n\n{{.Message}}` (bold title, blank line, then message body). Messages are sent with Markdown parse mode. |
+Set the following environment variable: `SUBSCRIPTIONS_FILE`
 
 - If the file exists and contains valid subscriptions, they will be loaded automatically on startup.
 - If the file is missing or empty, Gotigram will start normally with no subscriptions.
 - Update and save the subscriptions to a file at any time using the '/save' command.
 
-#### JSON File Format
+### JSON File Format
 
 The file must contain a JSON array of subscription objects, which have the following structure:
 
@@ -90,7 +97,7 @@ Example `subscriptions.json`
 ]
 ```
 
-## 🔧 How to Get Your Telegram Token and Chat ID
+## How to Get Your Telegram Token and Chat ID
 
 1. **Create a Telegram Bot**  
    Talk to [@BotFather](https://t.me/BotFather) and use the `/newbot` command to create your bot.  
@@ -103,7 +110,7 @@ Example `subscriptions.json`
    - Your `chat id` will appear in the response — that’s your `TELEGRAM_CHAT_ID`.
 
 
-## 🚀 Getting Started
+## Getting Started
 
 ### Option 1: Run Locally
 
@@ -121,6 +128,7 @@ export GOTIFY_CLIENT_TOKEN=<YOUR_GOTIFY_CLIENT_TOKEN>
 export TELEGRAM_TOKEN=<YOUR_TELEGRAM_BOT_TOKEN>
 export TELEGRAM_CHAT_ID=<YOUR_TELEGRAM_CHAT_ID>
 export SUBSCRIPTIONS_FILE=<path/to/json>  # Optional to set
+export TELEGRAM_TEMPLATE=''               # Optional to set
 
 ./gotigram
 ```
@@ -134,6 +142,7 @@ export SUBSCRIPTIONS_FILE=<path/to/json>  # Optional to set
 ```bash
 git clone https://github.com/Tiagura/gotigram.git
 cd gotigram
+mkdir subscriptions
 export MYUID=$(id -u)
 export MYGID=$(id -g)
 docker compose -f local-docker-compose.yml up -d
@@ -146,12 +155,13 @@ docker compose -f local-docker-compose.yml up -d
 ```bash
 git clone https://github.com/Tiagura/gotigram.git
 cd gotigram
+mkdir subscriptions
 export MYUID=$(id -u)
 export MYGID=$(id -g)
 docker compose -f docker-compose.yml up -d
 ```
 
-## 💬 Bot Usage
+## Bot Usage
 
 Once the bot is running, open a Telegram chat with it and send the `/start` command to begin. This step is optional but recommended, as it displays all available commands.
 
@@ -166,7 +176,7 @@ Once the bot is running, open a Telegram chat with it and send the `/start` comm
 - `/import` - Import subscriptions from a JSON array
 - `/save` - Save the current subscriptions to the configured subscriptions file (`SUBSCRIPTIONS_FILE`) for automatic loading on next startup.
 
-## 📥 Subscribing to Applications
+### Subscribing to Applications
 
 To start receiving Gotify messages in Telegram, you must subscribe to specific applications. This allows you to filter which messages you want forwarded. To find application IDs, use the command:
 
@@ -174,16 +184,15 @@ To start receiving Gotify messages in Telegram, you must subscribe to specific a
 /apps
 ```
 
-### Example
+#### Example
 
 <img src="images/subscribe_example.png" alt="subscribe_example" width="500"/>
 
-## 🧾 License
+## License
 
 This project is open-source and available under the [MIT License](LICENSE).
 
 
-## 🤝 Contributing
+## Contributing
 
 Feel free to open issues or submit pull requests to improve Gotigram!
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,14 @@ services:
     #  - .env
     # Option 2: Define variables inline
     environment:
-      GOTIFY_WS_URL: ws://<GOTIFY_SERVER>:<WS_PORT>
-      GOTIFY_REST_URL: http(s)://<GOTIFY_SERVER>:<REST_PORT>
+      # Required
       GOTIFY_CLIENT_TOKEN: <GOTIFY_CLIENT_TOKEN>
-      TELEGRAM_TOKEN: <TELEGRAM_TOKEN>
+      GOTIFY_REST_URL: http(s)://<GOTIFY_SERVER>:<REST_PORT>
+      GOTIFY_WS_URL: ws://<GOTIFY_SERVER>:<WS_PORT>
       TELEGRAM_CHAT_ID: <TELEGRAM_CHAT_ID>
+      TELEGRAM_TOKEN: <TELEGRAM_TOKEN>
+      # Optional
+      TELEGRAM_TEMPLATE: ""
       SUBSCRIPTIONS_FILE: /subscriptions/subscriptions.json
     # Optional: mount this volume to persist subscriptions outside container
     # Command /save won't work without this volume

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -8,11 +8,14 @@ services:
     #  - .env
     # Option 2: Define variables inline
     environment:
-      GOTIFY_WS_URL: ws://<GOTIFY_SERVER>:<WS_PORT>
-      GOTIFY_REST_URL: http(s)://<GOTIFY_SERVER>:<REST_PORT>
+      # Required
       GOTIFY_CLIENT_TOKEN: <GOTIFY_CLIENT_TOKEN>
-      TELEGRAM_TOKEN: <TELEGRAM_TOKEN>
+      GOTIFY_REST_URL: http(s)://<GOTIFY_SERVER>:<REST_PORT>
+      GOTIFY_WS_URL: ws://<GOTIFY_SERVER>:<WS_PORT>
       TELEGRAM_CHAT_ID: <TELEGRAM_CHAT_ID>
+      TELEGRAM_TOKEN: <TELEGRAM_TOKEN>
+      # Optional
+      TELEGRAM_TEMPLATE: ""
       SUBSCRIPTIONS_FILE: /subscriptions/subscriptions.json
     # Optional: mount this volume to persist subscriptions outside container
     # Command /save won't work without this volume


### PR DESCRIPTION
## Summary

- Add `TELEGRAM_TEMPLATE` env var for customizing forwarded message format using Go `text/template` syntax
- Default template: `*{{.Title}}*\n\n{{.Message}}` (bold title, blank line, message body)
- Enable Markdown parse mode for Telegram messages

Closes #1

## Test plan

- [x] `go build` compiles successfully
- [x] Unit tests pass for default, custom, markdown, invalid, and empty template scenarios
- [x] Manual test: Gotify message forwarded to Telegram with correct Markdown rendering