### PR TITLE
fix: auto-reconnect WebSocket when Gotify restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 *.dylib
 *.test
 
+# Compiled object files
+gotigram
+
 # Output of the Go build tool
 /bin/
 /build/

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/gorilla/websocket"
@@ -579,44 +580,55 @@ func fetchApps() ([]GotifyApp, error) {
 func listenGotify(bot *tgbotapi.BotAPI) {
 	url := fmt.Sprintf("%s/stream?token=%s", GOTIFY_WS_URL, GOTIFY_CLIENT_TOKEN)
 
-	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
-	if err != nil {
-		log.Fatalf("Failed to connect to Gotify WS: %v", err)
-	}
-	defer conn.Close()
-
-	log.Println("Connected to Gotify stream")
+	backoff := time.Second
+	const maxBackoff = 60 * time.Second
 
 	for {
-		_, data, err := conn.ReadMessage()
+		log.Printf("Connecting to Gotify stream...")
+		conn, _, err := websocket.DefaultDialer.Dial(url, nil)
 		if err != nil {
-			log.Printf("WebSocket error: %v", err)
-			return
-		}
-
-		var msg GotifyMessage
-		if err := json.Unmarshal(data, &msg); err != nil {
-			log.Printf("Error parsing message: %v", err)
+			log.Printf("Failed to connect to Gotify WS: %v, retrying in %v", err, backoff)
+			time.Sleep(backoff)
+			backoff = min(backoff*2, maxBackoff)
 			continue
 		}
+		log.Println("Connected to Gotify stream")
 
-		log.Printf("Gotify message from app %d: %s - %s (priority %d)", msg.AppID, msg.Title, msg.Message, msg.Priority)
-
-		subMu.RLock()
-		sub, subscribed := subscriptions[msg.AppID]
-		subMu.RUnlock()
-
-		if subscribed {
-			if msg.Priority >= sub.Priority {
-				log.Printf("Forwarding message from app %d (sub prio %d)", msg.AppID, sub.Priority)
-				text := fmt.Sprintf("%s - %s", msg.Title, msg.Message)
-				tg := tgbotapi.NewMessage(TELEGRAM_CHAT_ID, text)
-				bot.Send(tg)
-			} else {
-				log.Printf("Message priority %d < subscription priority %d, ignoring", msg.Priority, sub.Priority)
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				log.Printf("WebSocket error: %v, reconnecting in %v...", err, backoff)
+				conn.Close()
+				time.Sleep(backoff)
+				backoff = min(backoff*2, maxBackoff)
+				break
 			}
-		} else {
-			log.Printf("Message from unsubscribed app %d, ignoring", msg.AppID)
+			backoff = time.Second
+
+			var msg GotifyMessage
+			if err := json.Unmarshal(data, &msg); err != nil {
+				log.Printf("Error parsing message: %v", err)
+				continue
+			}
+
+			log.Printf("Gotify message from app %d: %s - %s (priority %d)", msg.AppID, msg.Title, msg.Message, msg.Priority)
+
+			subMu.RLock()
+			sub, subscribed := subscriptions[msg.AppID]
+			subMu.RUnlock()
+
+			if subscribed {
+				if msg.Priority >= sub.Priority {
+					log.Printf("Forwarding message from app %d (sub prio %d)", msg.AppID, sub.Priority)
+					text := fmt.Sprintf("%s - %s", msg.Title, msg.Message)
+					tg := tgbotapi.NewMessage(TELEGRAM_CHAT_ID, text)
+					bot.Send(tg)
+				} else {
+					log.Printf("Message priority %d < subscription priority %d, ignoring", msg.Priority, sub.Priority)
+				}
+			} else {
+				log.Printf("Message from unsubscribed app %d, ignoring", msg.AppID)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3

- Add reconnection loop with exponential backoff (1s to 60s) to `listenGotify()`
- Both `Dial` failures and `ReadMessage` errors now trigger backoff and retry instead of crashing or silently exiting
- Backoff resets only after successfully receiving a message, preventing tight reconnect loops when Gotify is flapping

## Test plan

- [x] Start gotigram with Gotify running, verify messages forward normally
- [x] Restart Gotify, verify gotigram reconnects automatically and resumes forwarding
- [x] Stop Gotify for an extended period, verify backoff increases up to 60s in logs
- [x] Restart Gotify after extended downtime, verify gotigram recovers