### PR TITLE
fix: add retry and error logging for Telegram send failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ To connect Gotigram to these services, you must provide certain configuration va
 
 | Variable              | Description                                                                            |
 |-----------------------|----------------------------------------------------------------------------------------|
-| `SUBSCRIPTIONS_FILE`  | Path to a JSON file containing predefined subscriptions. Defaults to `subscriptions.json`. See [how to use](#optional-subscriptions-configuration-file). |
-| `TELEGRAM_TEMPLATE` | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `{{.Title}}\n\n{{.Message}}`. Messages are sent with Markdown parse mode. **Wrap in `'...'` or `"..."`.** |
-| `ESCAPE_MARKDOWN` | Set to `true` to escape Markdown special characters in message title and body before template rendering. Defaults to `false`. Enable this if your Gotify sources send plain text that may contain characters like `_`, `*`, or `` ` `` which would break Markdown parsing. |
-
+| `SUBSCRIPTIONS_FILE`  | Path to a JSON file containing predefined subscriptions. Defaults to `subscriptions.json`. See [how to use](#subscriptions-configuration-file). |
+| `TELEGRAM_TEMPLATE`   | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `{{.Title}}\n\n{{.Message}}`. Messages are sent with Markdown parse mode. **Wrap in `'...'` or `"..."`.** |
+| `ESCAPE_MARKDOWN`     | Set to `true` to escape Markdown special characters in message title and body before template rendering. Defaults to `false`. Enable this if your Gotify sources send plain text that may contain characters like `_`, `*`, or `` ` `` which would break Markdown parsing. |
+| `MESSAGE_QUEUE_SIZE`  | Number of messages to be stored in the message queue. Defaults to `100`. Must be greater than `0`. |
+| `MAX_RETRIES`         | Maximum number of retry attempts when sending a message to Telegram fails. Defaults to `3`. Must be greater than `0`. |
 
 ## Subscriptions Configuration File
 
@@ -128,9 +129,7 @@ export GOTIFY_REST_URL=http(s)://<GOTIFY_SERVER>:<REST_PORT>
 export GOTIFY_CLIENT_TOKEN=<YOUR_GOTIFY_CLIENT_TOKEN>
 export TELEGRAM_TOKEN=<YOUR_TELEGRAM_BOT_TOKEN>
 export TELEGRAM_CHAT_ID=<YOUR_TELEGRAM_CHAT_ID>
-export SUBSCRIPTIONS_FILE=<path/to/json>  # Optional to set
-export TELEGRAM_TEMPLATE=''               # Optional to set
-export ESCAPE_MARKDOWN=false              # Optional to set
+# Set optional variables if needed the same way
 
 ./gotigram
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       TELEGRAM_TEMPLATE: ""
       ESCAPE_MARKDOWN: "false"
       SUBSCRIPTIONS_FILE: /subscriptions/subscriptions.json
+      MESSAGE_QUEUE_SIZE: 100
+      MAX_RETRIES: 3
     # Optional: mount this volume to persist subscriptions outside container
     # Command /save won't work without this volume
     # The startup import also requires this volume and to match the path defined in SUBSCRIPTIONS_FILE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gotigram
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -18,6 +18,8 @@ services:
       TELEGRAM_TEMPLATE: ""
       ESCAPE_MARKDOWN: "false"
       SUBSCRIPTIONS_FILE: /subscriptions/subscriptions.json
+      MESSAGE_QUEUE_SIZE: 100
+      MAX_RETRIES: 3
     # Optional: mount this volume to persist subscriptions outside container
     # Command /save won't work without this volume
     # The startup import also requires this volume and to match the path defined in SUBSCRIPTIONS_FILE

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/gorilla/websocket"
@@ -215,7 +217,33 @@ func startTelegram(bot *tgbotapi.BotAPI) {
 
 func reply(bot *tgbotapi.BotAPI, update tgbotapi.Update, text string) {
 	msg := tgbotapi.NewMessage(update.Message.Chat.ID, text)
-	bot.Send(msg)
+	if _, err := bot.Send(msg); err != nil {
+		log.Printf("Failed to send reply: %v", err)
+	}
+}
+
+func sendWithRetry(bot *tgbotapi.BotAPI, msg tgbotapi.Chattable, maxRetries int) {
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
+	backoff := time.Second
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		if _, err = bot.Send(msg); err == nil {
+			return
+		}
+		log.Printf("Telegram send failed (attempt %d/%d): %v", i+1, maxRetries, err)
+		// Don't retry client errors (4xx) — they will never succeed
+		var apiErr *tgbotapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code >= 400 && apiErr.Code < 500 {
+			return
+		}
+		if i < maxRetries-1 {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+	log.Printf("Telegram send failed after %d attempts: %v", maxRetries, err)
 }
 
 /* -------------------
@@ -510,7 +538,9 @@ func handleExport(bot *tgbotapi.BotAPI, update tgbotapi.Update) {
 	)
 	msg.ParseMode = "Markdown"
 
-	bot.Send(msg)
+	if _, err := bot.Send(msg); err != nil {
+		log.Printf("Failed to send export message: %v", err)
+	}
 }
 
 func handleSave(bot *tgbotapi.BotAPI, update tgbotapi.Update) {
@@ -579,6 +609,16 @@ func fetchApps() ([]GotifyApp, error) {
 func listenGotify(bot *tgbotapi.BotAPI) {
 	url := fmt.Sprintf("%s/stream?token=%s", GOTIFY_WS_URL, GOTIFY_CLIENT_TOKEN)
 
+	// Buffered send queue: decouples WS reading from Telegram sending,
+	// caps memory usage, and preserves message order.
+	sendQueue := make(chan tgbotapi.Chattable, 100)
+	defer close(sendQueue)
+	go func() {
+		for msg := range sendQueue {
+			sendWithRetry(bot, msg, 3)
+		}
+	}()
+
 	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
 	if err != nil {
 		log.Fatalf("Failed to connect to Gotify WS: %v", err)
@@ -611,7 +651,11 @@ func listenGotify(bot *tgbotapi.BotAPI) {
 				log.Printf("Forwarding message from app %d (sub prio %d)", msg.AppID, sub.Priority)
 				text := fmt.Sprintf("%s - %s", msg.Title, msg.Message)
 				tg := tgbotapi.NewMessage(TELEGRAM_CHAT_ID, text)
-				bot.Send(tg)
+				select {
+				case sendQueue <- tg:
+				default:
+					log.Printf("Telegram send queue full, dropping message from app %d", msg.AppID)
+				}
 			} else {
 				log.Printf("Message priority %d < subscription priority %d, ignoring", msg.Priority, sub.Priority)
 			}

--- a/main.go
+++ b/main.go
@@ -48,6 +48,8 @@ var (
 	TELEGRAM_CHAT_ID    = mustInt64(mustEnv("TELEGRAM_CHAT_ID"))
 	SUBSCRIPTIONS_FILE  = getSubscriptionsFile()
 	ESCAPE_MARKDOWN     = parseBoolEnv("ESCAPE_MARKDOWN")
+	DEFAULT_MESSAGE_QUEUE_SIZE = 100
+	MAX_RETRIES = 3
 
 	subscriptions = make(map[int]Subscription)
 	subMu         sync.RWMutex
@@ -67,6 +69,38 @@ var (
 			log.Fatalf("Failed to parse TELEGRAM_TEMPLATE: %v", err)
 		}
 		return t
+	}()
+
+	messageQueueSize = func() int {
+
+		sizeStr := os.Getenv("MESSAGE_QUEUE_SIZE")
+		if sizeStr == "" {
+			return DEFAULT_MESSAGE_QUEUE_SIZE
+		}
+
+		size, err := strconv.Atoi(sizeStr)
+		if err != nil || size <= 0 {
+			log.Printf("Invalid MESSAGE_QUEUE_SIZE value: %q, must be > 0. Defaulting to %d", sizeStr, DEFAULT_MESSAGE_QUEUE_SIZE)
+			return DEFAULT_MESSAGE_QUEUE_SIZE
+		}
+
+		return size
+	}()
+
+	maxRetries = func() int {
+
+		retriesStr := os.Getenv("MAX_RETRIES")
+		if retriesStr == "" {
+			return MAX_RETRIES
+		}
+
+		retries, err := strconv.Atoi(retriesStr)
+		if err != nil || retries <= 0 {
+			log.Printf("Invalid MAX_RETRIES value: %q, must be > 0. Defaulting to %d", retriesStr, MAX_RETRIES)
+			return MAX_RETRIES
+		}
+
+		return retries
 	}()
 )
 
@@ -683,11 +717,11 @@ func listenGotify(bot *tgbotapi.BotAPI) {
 
 	// Buffered send queue: decouples WS reading from Telegram sending,
 	// caps memory usage, and preserves message order.
-	sendQueue := make(chan tgbotapi.Chattable, 100)
+	sendQueue := make(chan tgbotapi.Chattable, messageQueueSize)
 	defer close(sendQueue)
 	go func() {
 		for msg := range sendQueue {
-			sendWithRetry(bot, msg, 3)
+			sendWithRetry(bot, msg, maxRetries)
 		}
 	}()
 
@@ -748,9 +782,9 @@ func listenGotify(bot *tgbotapi.BotAPI) {
 					tg := tgbotapi.NewMessage(TELEGRAM_CHAT_ID, buf.String())
 					tg.ParseMode = "Markdown"
 					select {
-					case sendQueue <- tg:
-					default:
-						log.Printf("Telegram send queue full, dropping message from app %d", msg.AppID)
+						case sendQueue <- tg:	
+						default:
+							log.Printf("Telegram send queue full, dropping message from app %d", msg.AppID)
 					}
 				} else {
 					log.Printf("Message priority %d < subscription priority %d, ignoring", msg.Priority, sub.Priority)


### PR DESCRIPTION
## Summary

- Add `sendWithRetry()` with exponential backoff (3 attempts, 1s→2s→4s) for Gotify→Telegram forwarding
- Decouple WebSocket reading from Telegram sending via buffered channel (cap 100) + single worker goroutine
- Add error logging to all `bot.Send()` call sites (`reply()`, `handleExport()`)
- Guard `sendWithRetry` against invalid `maxRetries` parameter

Closes #5

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (no test files currently)
- [x] Manual: stop Telegram API access, verify retry logs appear and WebSocket reading continues
- [x] Manual: restore Telegram API access, verify queued messages are delivered in order