### PR TITLE
fix: make Markdown escaping opt-in via ESCAPE_MARKDOWN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ To connect Gotigram to these services, you must provide certain configuration va
 | Variable              | Description                                                                            |
 |-----------------------|----------------------------------------------------------------------------------------|
 | `SUBSCRIPTIONS_FILE`  | Path to a JSON file containing predefined subscriptions. Defaults to `subscriptions.json`. See [how to use](#optional-subscriptions-configuration-file). |
-| `TELEGRAM_TEMPLATE` | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `*{{.Title}}*\n\n{{.Message}}` (bold title, blank line, then message body). Messages are sent with Markdown parse mode. **Wrap in `'...'` or `"..."`.** | |
+| `TELEGRAM_TEMPLATE` | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `{{.Title}}\n\n{{.Message}}`. Messages are sent with Markdown parse mode. **Wrap in `'...'` or `"..."`.** |
+| `ESCAPE_MARKDOWN` | Set to `true` to escape Markdown special characters in message title and body before template rendering. Defaults to `false`. Enable this if your Gotify sources send plain text that may contain characters like `_`, `*`, or `` ` `` which would break Markdown parsing. |
 
 
 ## Subscriptions Configuration File
@@ -129,6 +130,7 @@ export TELEGRAM_TOKEN=<YOUR_TELEGRAM_BOT_TOKEN>
 export TELEGRAM_CHAT_ID=<YOUR_TELEGRAM_CHAT_ID>
 export SUBSCRIPTIONS_FILE=<path/to/json>  # Optional to set
 export TELEGRAM_TEMPLATE=''               # Optional to set
+export ESCAPE_MARKDOWN=false              # Optional to set
 
 ./gotigram
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       TELEGRAM_TOKEN: <TELEGRAM_TOKEN>
       # Optional
       TELEGRAM_TEMPLATE: ""
+      ESCAPE_MARKDOWN: "false"
       SUBSCRIPTIONS_FILE: /subscriptions/subscriptions.json
     # Optional: mount this volume to persist subscriptions outside container
     # Command /save won't work without this volume

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -16,6 +16,7 @@ services:
       TELEGRAM_TOKEN: <TELEGRAM_TOKEN>
       # Optional
       TELEGRAM_TEMPLATE: ""
+      ESCAPE_MARKDOWN: "false"
       SUBSCRIPTIONS_FILE: /subscriptions/subscriptions.json
     # Optional: mount this volume to persist subscriptions outside container
     # Command /save won't work without this volume


### PR DESCRIPTION
## Summary

- Add `ESCAPE_MARKDOWN` environment variable (default `false`) to control whether Markdown special characters are escaped before template rendering
- Change default template from `*{{.Title}}*\n\n{{.Message}}` to `{{.Title}}\n\n{{.Message}}` to avoid Markdown conflicts when escaping is off
- Use `strconv.ParseBool` for robust boolean parsing (supports `true/TRUE/1/false/0` etc.), with warning log on invalid values
- Update README, docker-compose.yml and local-docker-compose.yml to document the new option

Closes #7

## Rationale

Many Gotify sources (e.g. Proxmox VE) send messages with intentional Markdown formatting. Unconditional escaping destroys this formatting. Making it opt-in lets users choose based on their message sources.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (no test files currently)
- [x] Manual: verify messages render correctly with `ESCAPE_MARKDOWN` unset (default)
- [x] Manual: verify escaping works with `ESCAPE_MARKDOWN=true`
- [x] Manual: verify invalid value (e.g. `ESCAPE_MARKDOWN=yes`) logs warning and defaults to false