### PR TITLE
feat: logging and queue full behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To connect Gotigram to these services, you must provide certain configuration va
 | `MESSAGE_QUEUE_SIZE`  | Number of messages to be stored in the message queue. Defaults to `100`. Must be greater than `0`. |
 | `MAX_RETRIES`         | Maximum number of retry attempts when sending a message to Telegram fails. Defaults to `3`. Must be greater than `0`. |
 | `PARSE_MODE`          | Controls how Telegram renders message formatting via the Bot API `parse_mode`. Supported values: `Plain`, `Markdown`, `MarkdownV2`, and `HTML`. Defaults to `Markdown` if not set. |
+| `QUEUE_FULL_BEHAVIOR` | Behavior when the message queue is full. Supported values: `drop`, `fifo`. Defaults to `drop` if not set. |
 | `TELEGRAM_TEMPLATE`   | Custom Go `text/template` for Telegram messages. Available variables: `{{.Title}}` and `{{.Message}}`. Defaults to `{{.Title}}\n\n{{.Message}}`. |
 | `SUBSCRIPTIONS_FILE`  | Path to a JSON file containing predefined subscriptions. Defaults to `subscriptions.json`. See [how to use](#subscriptions-configuration-file). |
 
@@ -83,7 +84,7 @@ The file must contain a JSON array of subscription objects, which have the follo
 | `ID`       | Yes      | Gotify application ID                                                                           |
 | `Name`     | No       | Human-readable application name (used in Telegram messages; defaults to `""` if omitted)        |
 | `Priority` | No       | Minimum priority (0–10) for notifications. Defaults to `0`                                      |
-| `Format`   | No       | Message parse mode. Check [`PARSE_MODE`](#optional-environment-variables) env var.              |
+| `ParseMode`| No       | Message parse mode. Check [`PARSE_MODE`](#optional-environment-variables) env var.              |
 
 
 Example `subscriptions.json`

--- a/src/config.go
+++ b/src/config.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -12,16 +12,25 @@ import (
 )
 
 const (
-	ParseModePlain           ParseMode = "Plain"
-	ParseModeMarkdown        ParseMode = "Markdown"
-	ParseModeMarkdownV2      ParseMode = "MarkdownV2"
-	ParseModeHTML            ParseMode = "HTML"
-	maxTelegramMessageLength           = 4096
-	defaultMessageQueueSize            = 100
-	defaultMaxRetries                  = 3
+	ParseModePlain      ParseMode = "Plain"
+	ParseModeMarkdown   ParseMode = "Markdown"
+	ParseModeMarkdownV2 ParseMode = "MarkdownV2"
+	ParseModeHTML       ParseMode = "HTML"
+
+	maxTelegramMessageLength = 4096
+	defaultMessageQueueSize  = 100
+	defaultMaxRetries        = 3
+	defaultQueueFullBehavior = QueueFullDrop
 )
 
 type ParseMode string
+
+type QueueFullBehavior string
+
+const (
+	QueueFullDrop  QueueFullBehavior = "drop"
+	QueueFullFIFO  QueueFullBehavior = "fifo"
+)
 
 type Config struct {
 	GotifyWSURL       string
@@ -33,12 +42,65 @@ type Config struct {
 	DefaultParseMode  ParseMode
 	MessageQueueSize  int
 	MaxRetries        int
+	QueueFullBehavior QueueFullBehavior
 	TelegramTemplate  *template.Template
 	HTTPClient        *http.Client
 	RetryMaxBackoff   time.Duration
 }
 
-func loadConfig() *Config {
+func LoadConfig() (*Config, error) {
+	cfg := &Config{
+		GotifyWSURL:       os.Getenv("GOTIFY_WS_URL"),
+		GotifyRESTURL:     os.Getenv("GOTIFY_REST_URL"),
+		GotifyClientToken: os.Getenv("GOTIFY_CLIENT_TOKEN"),
+		TelegramToken:     os.Getenv("TELEGRAM_TOKEN"),
+		SubscriptionsFile: getSubscriptionsFile(),
+		DefaultParseMode:  ParseModeMarkdown,
+		MessageQueueSize:  defaultMessageQueueSize,
+		MaxRetries:        defaultMaxRetries,
+		QueueFullBehavior: defaultQueueFullBehavior,
+		RetryMaxBackoff:   60 * time.Second,
+		HTTPClient:        &http.Client{Timeout: 10 * time.Second},
+	}
+
+	if v := os.Getenv("TELEGRAM_CHAT_ID"); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("TELEGRAM_CHAT_ID must be an integer: %w", err)
+		}
+		cfg.TelegramChatID = id
+	}
+	if v := os.Getenv("MESSAGE_QUEUE_SIZE"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("MESSAGE_QUEUE_SIZE must be a positive integer, got %q", v)
+		}
+		cfg.MessageQueueSize = n
+	}
+	if v := os.Getenv("MAX_RETRIES"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("MAX_RETRIES must be a positive integer, got %q", v)
+		}
+		cfg.MaxRetries = n
+	}
+	if v := os.Getenv("QUEUE_FULL_BEHAVIOR"); v != "" {
+		behavior := QueueFullBehavior(strings.ToLower(strings.TrimSpace(v)))
+		switch behavior {
+		case QueueFullDrop, QueueFullFIFO:
+			cfg.QueueFullBehavior = behavior
+		default:
+			return nil, fmt.Errorf("invalid QUEUE_FULL_BEHAVIOR %q: must be %q or %q", v, QueueFullDrop, QueueFullFIFO)
+		}
+	}
+	if v := os.Getenv("PARSE_MODE"); v != "" {
+		parseMode, err := parseFormat(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid PARSE_MODE: %w", err)
+		}
+		cfg.DefaultParseMode = parseMode
+	}
+
 	templateText := os.Getenv("TELEGRAM_TEMPLATE")
 	if templateText == "" {
 		templateText = "{{.Title}}\n\n{{.Message}}"
@@ -47,39 +109,43 @@ func loadConfig() *Config {
 	}
 	tmpl, err := template.New("telegram").Parse(templateText)
 	if err != nil {
-		log.Fatalf("Failed to parse TELEGRAM_TEMPLATE: %v", err)
+		return nil, fmt.Errorf("invalid TELEGRAM_TEMPLATE: %w", err)
 	}
-
-	queueSize := envPositiveInt("MESSAGE_QUEUE_SIZE", defaultMessageQueueSize)
-	maxRetries := envPositiveInt("MAX_RETRIES", defaultMaxRetries)
-	parseMode := ParseModeMarkdown
-	if v := os.Getenv("PARSE_MODE"); v != "" {
-		parseMode, err = parseFormat(v)
-		if err != nil {
-			log.Fatalf("Invalid PARSE_MODE: %v", err)
-		}
-	}
-
-	return &Config{
-		GotifyWSURL: mustEnv("GOTIFY_WS_URL"), GotifyRESTURL: mustEnv("GOTIFY_REST_URL"),
-		GotifyClientToken: mustEnv("GOTIFY_CLIENT_TOKEN"), TelegramToken: mustEnv("TELEGRAM_TOKEN"),
-		TelegramChatID: mustInt64(mustEnv("TELEGRAM_CHAT_ID")), SubscriptionsFile: getSubscriptionsFile(),
-		DefaultParseMode: parseMode, MessageQueueSize: queueSize, MaxRetries: maxRetries,
-		TelegramTemplate: tmpl, HTTPClient: &http.Client{Timeout: 10 * time.Second}, RetryMaxBackoff: 60 * time.Second,
-	}
+	cfg.TelegramTemplate = tmpl
+	return cfg, cfg.Validate()
 }
 
-func envPositiveInt(key string, fallback int) int {
-	v := os.Getenv(key)
-	if v == "" {
-		return fallback
+func (c *Config) Validate() error {
+	var missing []string
+	required := map[string]string{
+		"GOTIFY_WS_URL": c.GotifyWSURL, "GOTIFY_REST_URL": c.GotifyRESTURL,
+		"GOTIFY_CLIENT_TOKEN": c.GotifyClientToken, "TELEGRAM_TOKEN": c.TelegramToken,
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n <= 0 {
-		log.Printf("Invalid %s value %q, defaulting to %d", key, v, fallback)
-		return fallback
+	for key, value := range required {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+		}
 	}
-	return n
+	if c.TelegramChatID == 0 {
+		missing = append(missing, "TELEGRAM_CHAT_ID")
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	}
+	if c.MessageQueueSize <= 0 {
+		return fmt.Errorf("MESSAGE_QUEUE_SIZE must be positive")
+	}
+	if c.MaxRetries <= 0 {
+		return fmt.Errorf("MAX_RETRIES must be positive")
+	}
+	if c.QueueFullBehavior != QueueFullDrop && c.QueueFullBehavior != QueueFullFIFO {
+		return fmt.Errorf("invalid queue full behavior %q", c.QueueFullBehavior)
+	}
+	if c.TelegramTemplate == nil {
+		return fmt.Errorf("telegram template is not configured")
+	}
+	return nil
 }
 
 func unescapeEnv(s string) string {
@@ -106,26 +172,15 @@ func parseFormat(s string) (ParseMode, error) {
 	}
 }
 
-func mustEnv(key string) string {
-	v := os.Getenv(key)
-	if v == "" {
-		log.Fatalf("Missing env var: %s", key)
-	}
-	return v
-}
-
-func mustInt64(s string) int64 {
-	v, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return v
-}
-
 func getSubscriptionsFile() string {
 	path := os.Getenv("SUBSCRIPTIONS_FILE")
 	if path == "" {
 		path = "subscriptions.json" // default path if not set
 	}
 	return path
+}
+
+func (c *Config) String() string {
+	return fmt.Sprintf("GOTIFY_WS_URL: %s\nGOTIFY_REST_URL: %s\nTELEGRAM_CHAT_ID: %d\nSUBSCRIPTIONS_FILE: %s\nDEFAULT_PARSE_MODE: %s\nMESSAGE_QUEUE_SIZE: %d\nMAX_RETRIES: %d\nQUEUE_FULL_BEHAVIOR: %s\nTELEGRAM_TEMPLATE: %s",
+		c.GotifyWSURL, c.GotifyRESTURL, c.TelegramChatID, c.SubscriptionsFile, c.DefaultParseMode, c.MessageQueueSize, c.MaxRetries, c.QueueFullBehavior, c.TelegramTemplate.Tree.Root.String())
 }

--- a/src/gotify.go
+++ b/src/gotify.go
@@ -32,7 +32,7 @@ func (g *GotifyClient) FetchApps() ([]GotifyApp, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Gotify returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("Gotify application request returned HTTP %d", resp.StatusCode)
 	}
 
 	var apps []GotifyApp
@@ -181,12 +181,35 @@ func (g *GotifyClient) Listen(ctx context.Context) {
 				} else {
 					tg.ParseMode = string(sub.ParseMode)
 				}
-				select {
-				case sendQueue <- tg:
-				case <-ctx.Done():
-					return
-				default:
-					log.Printf("Telegram send queue full, dropping message from app %d", msg.AppID)
+				switch g.app.Config.QueueFullBehavior {
+				case QueueFullFIFO:
+					select {
+					case sendQueue <- tg:
+					default:
+							// Queue is full: evict the oldest queued message to make room,
+							// so the queue always holds the most recent messages rather than
+							// stalling the reader or silently dropping the newest one.
+							select {
+							case <-sendQueue:
+									log.Printf("Telegram send queue full; dropping oldest queued message to make room for message from app %d", msg.AppID)
+							default:
+									// Queue drained concurrently by the worker between the two
+									// selects above - nothing to evict, just proceed to enqueue.
+							}
+							select {
+							case sendQueue <- tg:
+							case <-ctx.Done():
+									return
+							}
+					}
+				case QueueFullDrop:
+					select {
+					case sendQueue <- tg:
+					case <-ctx.Done():
+						return
+					default:
+						log.Printf("Telegram send queue full; dropping message from app %d", msg.AppID)
+					}
 				}
 			}
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -15,17 +15,22 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	cfg := loadConfig()
+	cfg, err := LoadConfig()
+	if err != nil {
+		log.Fatalf("Configuration error: %v", err)
+	}
 	bot, err := tgbotapi.NewBotAPI(cfg.TelegramToken)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Authorized as %s", bot.Self.UserName)
-	log.Printf("Subscriptions file: %s", cfg.SubscriptionsFile)
+	log.Printf("Configuration:\n%s", cfg.String())
 
 	app := NewApp(cfg, bot)
 	if cfg.SubscriptionsFile != "" {
-		app.LoadSubscriptions(cfg.SubscriptionsFile)
+		if err := app.LoadSubscriptions(cfg.SubscriptionsFile); err != nil {
+			log.Fatalf("Failed to load subscriptions: %v", err)
+		}
 	}
 
 	var wg sync.WaitGroup

--- a/src/subscriptions.go
+++ b/src/subscriptions.go
@@ -8,32 +8,28 @@ import (
 	"sort"
 )
 
-func (a *App) LoadSubscriptions(path string) {
+func (a *App) LoadSubscriptions(path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		log.Printf("Failed to read subscriptions file %s: %v", path, err)
-		// If file doesn't exist it means no subscriptions yet, so just create an empty one
 		if os.IsNotExist(err) {
-			log.Printf("Creating empty subscriptions file at %s", path)
-			err = os.WriteFile(path, []byte("[]"), 0644)
-			if err != nil {
-				log.Printf("Failed to create empty subscriptions file at %s: %v", path, err)
+			log.Printf("Subscriptions file %s does not exist; starting with no subscriptions", path)
+			if err := os.WriteFile(path, []byte("[]"), 0644); err != nil {
+				return fmt.Errorf("create empty subscriptions file %s: %w", path, err)
 			}
+			return nil
 		}
-		return
+		return fmt.Errorf("read subscriptions file %s: %w", path, err)
 	}
 
 	var subs []Subscription
 	if err := json.Unmarshal(data, &subs); err != nil {
-		log.Printf("Failed to parse subscriptions JSON from %s: %v", path, err)
-		return
+		return fmt.Errorf("parse subscriptions JSON from %s: %w", path, err)
 	}
 
 	// Fetch current Gotify applications
 	apps, err := a.Gotify.FetchApps()
 	if err != nil {
-		log.Printf("Failed to fetch Gotify apps while loading subscriptions: %v", err)
-		return
+		return fmt.Errorf("fetch Gotify apps while loading subscriptions: %w", err)
 	}
 
 	// Build a map for quick lookup
@@ -51,9 +47,6 @@ func (a *App) LoadSubscriptions(path string) {
 		}
 
 		f := a.Config.DefaultParseMode
-		// if parse mode is missing, use default; if it's invalid, log and use default
-		// missing means nil, invalid means not one of the allowed values
-
 		if sub.ParseMode != "" {
 			parsed, err := parseFormat(string(sub.ParseMode))
 			if err != nil {
@@ -80,6 +73,7 @@ func (a *App) LoadSubscriptions(path string) {
 	}
 
 	log.Printf("Loaded %d subscriptions from %s", added, path)
+	return nil
 }
 
 func (a *App) SaveSubscriptions(path string) error {

--- a/src/telegram.go
+++ b/src/telegram.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"html"
 	"log"
-	// "os"
 	"sort"
 	"strconv"
 	"strings"


### PR DESCRIPTION
# Summary

This PR introduces improved logging and configurable behavior for handling cases where the queue is full.

## Changes

- Improved logging overall.
- Configurable queue-full behavior, with `QUEUE_FULL_BEHAVIOR` env var:
  - `drop` — discard new items when the queue is full.
  - `fifo` — remove the oldest item from the queue to make room for the new item.
